### PR TITLE
Use std::unordered_map as hash_map when available

### DIFF
--- a/source/Hash.h
+++ b/source/Hash.h
@@ -33,6 +33,9 @@
 
 #ifndef HASH_INCLUDED
 #define HASH_INCLUDED
+
+#if __cplusplus < 201103L
+
 #ifdef WIN32
 #include <hash_map>
 using stdext::hash_map;
@@ -61,4 +64,11 @@ struct hash< const unsigned long long > {
 };
 }
 #endif // WIN32
+
+#else // __cplusplus >= 201103L
+#include <unordered_map>
+template<class Key, class Value>
+using hash_map = std::unordered_map<Key, Value>;
+#endif // __cplusplus
+
 #endif // HASH_INCLUDED

--- a/source/MultiGridOctreeData.h
+++ b/source/MultiGridOctreeData.h
@@ -283,11 +283,6 @@ public:
                         bool addBarycenter);
 
   static int AddTriangles(CoredMeshData *mesh,
-                          std::vector< CoredPointIndex > edges[3],
-                          std::vector< Point3D< float > > *interiorPositions,
-                          const int & offSet);
-
-  static int AddTriangles(CoredMeshData *mesh,
                           std::vector< CoredPointIndex > & edges,
                           std::vector< Point3D< float > > *interiorPositions,
                           const int & offSet,

--- a/source/MultiGridOctreeData.inl
+++ b/source/MultiGridOctreeData.inl
@@ -2654,14 +2654,6 @@ inline int Octree<Degree>::GetEdgeLoops(std::vector<std::pair<long long,long lon
 }
 
 template<int Degree>
-inline int Octree<Degree>::AddTriangles(CoredMeshData* mesh,std::vector<CoredPointIndex> edges[3],std::vector<Point3D<float> >* interiorPositions,const int& offSet)
-{
-	std::vector<CoredPointIndex> e;
-	for(int i=0;i<3;i++){for(size_t j=0;j<edges[i].size();j++){e.push_back(edges[i][j]);}}
-	return AddTriangles(mesh,e,interiorPositions,offSet);
-}
-
-template<int Degree>
 int Octree<Degree>::AddTriangles( CoredMeshData* mesh , std::vector<CoredPointIndex>& edges , std::vector<Point3D<float> >* interiorPositions , const int& offSet , bool addBarycenter )
 {
         if( edges.size()>3 )


### PR DESCRIPTION
Resolves deprecation warnings with GCC 6.4 and compile errors with GCC 7.3