### PR TITLE
Update cmake minimum version required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.0)
 
 project(PoissonReconstruction)
 


### PR DESCRIPTION
Fixes a problem with policy CMP0048 when external projects use VERSION in project() command.