### PR TITLE
Fix small issues leading to warnings from GCC 7.3

### DIFF
--- a/source/MultiGridOctreeData.inl
+++ b/source/MultiGridOctreeData.inl
@@ -2661,7 +2661,9 @@ int Octree<Degree>::AddTriangles( CoredMeshData* mesh , std::vector<CoredPointIn
           bool isCoplanar = false;
 
           for( size_t i=0 ; i<edges.size() ; i++ )
+          {
             for( size_t j=0 ; j<i ; j++ )
+            {
               if( (i+1)%edges.size()!=j && (j+1)%edges.size()!=i )
               {
                 Point3D< Real > v1 , v2;
@@ -2671,7 +2673,9 @@ int Octree<Degree>::AddTriangles( CoredMeshData* mesh , std::vector<CoredPointIn
                 else for( int k=0 ; k<3 ; k++ ) v2.coords[k] = (*interiorPositions)[ edges[j].index-offSet ].coords[k];
                 for( int k=0 ; k<3 ; k++ ) if( v1.coords[k]==v2.coords[k] ) isCoplanar = true;
               }
-            if( addBarycenter && isCoplanar )
+            }
+          }
+          if( addBarycenter && isCoplanar )
 #else
           if( addBarycenter )
 #endif

--- a/source/MultiGridOctreeData.inl
+++ b/source/MultiGridOctreeData.inl
@@ -1652,7 +1652,6 @@ inline Real Octree<Degree>::GetIsoValue(void)
 		fData.setValueTables(fData.VALUE_FLAG,0);
 		cf.valueTables=fData.valueTables;
 		cf.res2=fData.res2;
-		Real myRadius=radius;
 		isoValue=weightSum=0;
 		temp=tree.nextNode();
 		while(temp){


### PR DESCRIPTION
This fixes small issues in `MultiGridOctreeData.inl` leading to GCC 7.3 warnings:
```
PoissonReconstruction/source/MultiGridOctreeData.inl:1655:8: warning: unused variable ‘myRadius’ [-Wunused-variable]
```
and
```
PoissonReconstruction/source/MultiGridOctreeData.inl: In static member function ‘static int Octree<Degree>::AddTriangles(CoredMeshData*, std::vector<CoredPointIndex>&, std::vector<Point3D<float> >*, const int&, bool)’:
PoissonReconstruction/source/MultiGridOctreeData.inl:2664:11: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
           for( size_t i=0 ; i<edges.size() ; i++ )
           ^~~
PoissonReconstruction/source/MultiGridOctreeData.inl:2675:13: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘for’
             if( addBarycenter && isCoplanar )
             ^~
```